### PR TITLE
Release 3.3.0

### DIFF
--- a/aws-cloudformation/README.md
+++ b/aws-cloudformation/README.md
@@ -36,7 +36,7 @@ If you have an existing AWS account (with billing and an SSH key pair), just cli
 **WARNING:** if you have an existing sandbox server created before Dec 31, 2019 (v1), **DO NOT UPGRADE**.  
 See [v2.0.0](https://github.com/docksal/sandbox-server/releases/tag/v2.0.0) release notes.
 
-[![Launch Basic Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=docksal-sandbox-server&templateURL=https://s3.us-east-2.amazonaws.com/docksal-aws-templates/sandbox-server/v3/basic.json)
+[![Launch Basic Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=docksal-sandbox-server&templateURL=https://docksal-aws-templates.s3.us-east-2.amazonaws.com/sandbox-server/v3.3.0/basic.json) (v3.3.0)
 
 You will be prompted for:
 
@@ -60,15 +60,15 @@ If you have an existing AWS account (with billing and an SSH key pair), just cli
 **WARNING:** if you have an existing sandbox server created before Dec 31, 2019 (v1), **DO NOT UPGRADE**.  
 See [v2.0.0](https://github.com/docksal/sandbox-server/releases/tag/v2.0.0) release notes.
 
-[![Launch Advanced Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=docksal-sandbox-server&templateURL=https://s3.us-east-2.amazonaws.com/docksal-aws-templates/sandbox-server/v3/advanced.json)
+[![Launch Advanced Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=docksal-sandbox-server&templateURL=https://docksal-aws-templates.s3.us-east-2.amazonaws.com/sandbox-server/v3.3.0/advanced.json) (v3.3.0)
 
 You will be prompted for a few required and optional settings.
 
 - Basic: Required
   - Resource type (`ec2` vs `spot`)
+  - Instance architecture (`amd64` vs `arm64`)
   - Instance type (primary)
-  - Instance type 2 (spot only)
-  - Instance type 3 (spot only)
+  - Instance type 2 (`spot` mode only)
   - SSH key
   - Availability zone
 - VPC/Network: Optional

--- a/aws-cloudformation/README.md
+++ b/aws-cloudformation/README.md
@@ -11,6 +11,8 @@ AWS CloudFormation handles all of that.
 
 For an overview of AWS CloudFormation, see the [AWS CloudFormation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html.)
 
+See [Releases](https://github.com/docksal/sandbox-server/releases) for the most recent AWS CloudFormation template links.
+
 <a name="features"></a>
 ## Features
 
@@ -27,7 +29,6 @@ For an overview of AWS CloudFormation, see the [AWS CloudFormation User Guide](h
   - [Access restriction by IP range](#access-ip)
   - [Manage SSH access via Github org/team](#access-ssh)
 
-
 <a name="basic"></a>
 ## Basic mode: Quick setup (using CloudFormation web UI)
 
@@ -36,7 +37,7 @@ If you have an existing AWS account (with billing and an SSH key pair), just cli
 **WARNING:** if you have an existing sandbox server created before Dec 31, 2019 (v1), **DO NOT UPGRADE**.  
 See [v2.0.0](https://github.com/docksal/sandbox-server/releases/tag/v2.0.0) release notes.
 
-[![Launch Basic Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=docksal-sandbox-server&templateURL=https://docksal-aws-templates.s3.us-east-2.amazonaws.com/sandbox-server/v3.3.0/basic.json) (v3.3.0)
+[![Launch Basic Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=docksal-sandbox-server&templateURL=https://docksal-aws-templates.s3.us-east-2.amazonaws.com/sandbox-server/v3.3.0/basic.json)
 
 You will be prompted for:
 
@@ -60,7 +61,7 @@ If you have an existing AWS account (with billing and an SSH key pair), just cli
 **WARNING:** if you have an existing sandbox server created before Dec 31, 2019 (v1), **DO NOT UPGRADE**.  
 See [v2.0.0](https://github.com/docksal/sandbox-server/releases/tag/v2.0.0) release notes.
 
-[![Launch Advanced Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=docksal-sandbox-server&templateURL=https://docksal-aws-templates.s3.us-east-2.amazonaws.com/sandbox-server/v3.3.0/advanced.json) (v3.3.0)
+[![Launch Advanced Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=docksal-sandbox-server&templateURL=https://docksal-aws-templates.s3.us-east-2.amazonaws.com/sandbox-server/v3.3.0/advanced.json)
 
 You will be prompted for a few required and optional settings.
 

--- a/aws-cloudformation/tpl-advanced.yaml
+++ b/aws-cloudformation/tpl-advanced.yaml
@@ -599,10 +599,7 @@ Resources:
           - &instance-profile
             InstanceType: !Ref InstanceType
             IamInstanceProfile:
-              Arn:
-                Fn::GetAtt:
-                  - spotInstanceProfile
-                  - Arn
+              Arn: !GetAtt spotInstanceProfile.Arn
             Placement:
               AvailabilityZone: !Ref ManualAZ
             TagSpecifications:

--- a/aws-cloudformation/tpl-advanced.yaml
+++ b/aws-cloudformation/tpl-advanced.yaml
@@ -14,14 +14,22 @@ Parameters:
     AllowedValues:
       - ec2
       - spot
+  InstanceArch:
+    Description: |
+      EC2 instance architecture.
+      Use "amd64" for t3/t3a and "arm64" for t4g instance types.
+      IMPORTANT: Instance will fail to start if architecture and type (below) are mismatched.
+    Type: String
+    Default: amd64
+    AllowedValues:
+      - amd64
+      - arm64
   InstanceType:
     Description: |
       EC2 instance type (default: t3.small = 2 vCPU, 2GB RAM).
       t3 (Intel) / t3a (AMD) family instances provide burstable CPU performance and are generally the best choise for a sandbox server.
-      t3/t3a: CPU/RAM ratio is variable from 1/1 to 1/4 based on instance size (t3.large = 2 vCPU, 8GB RAM).
-      c5: CPU/RAM ratio is 1/2 (c5.large = 2 vCPU, 4GB RAM).
-      m5: CPU/RAM ratio is 1/4 (m5.large = 2 vCPU, 8GB RAM).
-      r5: CPU/RAM ratio is 1/8 (r5.large = 2 vCPU, 16GB RAM).
+      t4g (ARM64) family instances deliver up to 40% better price performance over T3 instances.
+      t3/t3a/t4g: CPU/RAM ratio is variable from 1/1 to 1/4 based on instance size (t3.large = 2 vCPU, 8GB RAM).
     Type: String
     Default: t3.small
     AllowedValues:
@@ -35,22 +43,17 @@ Parameters:
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
-      - c5.large
-      - c5.xlarge
-      - c5.2xlarge
-      - c5.4xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - r5.large
-      - r5.xlarge
-      - r5.2xlarge
+      - t4g.small
+      - t4g.medium
+      - t4g.large
+      - t4g.xlarge
+      - t4g.2xlarge
   InstanceType2:
     Description: |
       Additional EC2 instance type (spot mode only). AWS will pick the cheapest available option for spot instance.
       IMPORTANT: "Instance Type"/"Instance Type 2" must be unique, overwise stack creation/update will fail.
       Recomendation: Use a "t3" instance for the primary option and a matching size "t3a" instance type here.
+      Do not mix Intel/AMD with ARM64 (g) instances unless you know what you are doing.
     Type: String
     Default: t3.medium
     AllowedValues:
@@ -64,17 +67,11 @@ Parameters:
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
-      - c5.large
-      - c5.xlarge
-      - c5.2xlarge
-      - c5.4xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - r5.large
-      - r5.xlarge
-      - r5.2xlarge
+      - t4g.small
+      - t4g.medium
+      - t4g.large
+      - t4g.xlarge
+      - t4g.2xlarge
   KeyName:
     Description: "Name of an existing EC2 KeyPair to enable SSH access to the instance"
     Type: "AWS::EC2::KeyPair::KeyName"
@@ -183,6 +180,7 @@ Metadata:
           default: "Basic: Required"
         Parameters:
           - ResourceType
+          - InstanceArch
           - InstanceType
           - InstanceType2
           - KeyName
@@ -223,6 +221,8 @@ Metadata:
     ParameterLabels:
       ResourceType:
         default: "Resource type"
+      InstanceArch:
+        default: "Instance architecture"
       InstanceType:
         default: "Instance type (primary)"
       InstanceType2:
@@ -272,7 +272,8 @@ Mappings:
   Variables:
     LatestAmiId:
       # Get the latest AMI ID from Canonical's public Systems Manager Parameter
-      Value: "{{resolve:ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id}}"
+      amd64: "{{resolve:ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id}}"
+      arm64: "{{resolve:ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/arm64/hvm/ebs-gp2/ami-id}}"
 
 Conditions:
   CreateEC2: !Equals [!Ref ResourceType, "ec2"]
@@ -607,7 +608,7 @@ Resources:
                 Tags:
                 - Key: StackId
                   Value: !Ref AWS::StackId
-            ImageId: !FindInMap [Variables, LatestAmiId, Value]
+            ImageId: !FindInMap [Variables, LatestAmiId, !Ref InstanceArch]
             KeyName: !Ref KeyName
             SecurityGroups:
               - GroupId: !GetAtt InstanceSecurityGroup.GroupId
@@ -640,7 +641,7 @@ Resources:
       IamInstanceProfile: !Ref ec2InstanceProfile
       InstanceType: !Ref InstanceType
       AvailabilityZone: !Ref ManualAZ
-      ImageId: !FindInMap [Variables, LatestAmiId, Value]
+      ImageId: !FindInMap [Variables, LatestAmiId, !Ref InstanceArch]
       KeyName: !Ref KeyName
       Tags:
       - Key: StackId

--- a/aws-cloudformation/tpl-basic.yaml
+++ b/aws-cloudformation/tpl-basic.yaml
@@ -12,17 +12,6 @@ Parameters:
       - t3.large
       - t3.xlarge
       - t3.2xlarge
-      - c5.large
-      - c5.xlarge
-      - c5.2xlarge
-      - c5.4xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - r5.large
-      - r5.xlarge
-      - r5.2xlarge
   KeyName:
     Description: "Name of an existing EC2 KeyPair to enable SSH access to the instance"
     Type: "AWS::EC2::KeyPair::KeyName"

--- a/gcp-deployment-manager/templates/docksal_template.jinja
+++ b/gcp-deployment-manager/templates/docksal_template.jinja
@@ -26,7 +26,7 @@ resources:
         boot: true
         autoDelete: true
         initializeParams:
-          sourceImage: https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2004-focal-v20211209
+          sourceImage: https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2004-focal-v20220331
       - deviceName: docksal-sandbox-disk-data
         source: docksal-sandbox-disk
       {% if properties["startup"] or properties["docksalDnsDomain"] %}

--- a/gcp-deployment-manager/templates/docksal_template.jinja
+++ b/gcp-deployment-manager/templates/docksal_template.jinja
@@ -26,7 +26,7 @@ resources:
         boot: true
         autoDelete: true
         initializeParams:
-          sourceImage: https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2004-focal-v20211120
+          sourceImage: https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2004-focal-v20211209
       - deviceName: docksal-sandbox-disk-data
         source: docksal-sandbox-disk
       {% if properties["startup"] or properties["docksalDnsDomain"] %}


### PR DESCRIPTION
## AWS

- Dropped support for `c5`/`r5`/`m5` instance types
- Added support for `t4g` instance family in the advanced template
- Updated **Launch Stack** links in README
  - Use specific release URLs to avoid issues with CloudFormation caching template files

Templates:

- Basic: [v3.3.0](https://docksal-aws-templates.s3.us-east-2.amazonaws.com/sandbox-server/v3.3.0/basic.json)
- Advanced: [v3.3.0](https://docksal-aws-templates.s3.us-east-2.amazonaws.com/sandbox-server/v3.3.0/advanced.json)

## GCP

- Updated base Ubuntu 20.04 image - `ubuntu-minimal-2004-focal-v20220331`
