### PR TITLE
Release 3.4.0

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -23,7 +23,7 @@ env:
 jobs:
   aws-templates:
     name: "Publish: ${{ matrix.template }} template"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false # Don't cancel other jobs if one fails
@@ -35,7 +35,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 #      -
 #        name: Environment variables
 #        run: |

--- a/aws-cloudformation/tpl-advanced.yaml
+++ b/aws-cloudformation/tpl-advanced.yaml
@@ -272,8 +272,8 @@ Mappings:
   Variables:
     LatestAmiId:
       # Get the latest AMI ID from Canonical's public Systems Manager Parameter
-      amd64: "{{resolve:ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id}}"
-      arm64: "{{resolve:ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/arm64/hvm/ebs-gp2/ami-id}}"
+      amd64: "{{resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id}}"
+      arm64: "{{resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/arm64/hvm/ebs-gp2/ami-id}}"
 
 Conditions:
   CreateEC2: !Equals [!Ref ResourceType, "ec2"]

--- a/aws-cloudformation/tpl-basic.yaml
+++ b/aws-cloudformation/tpl-basic.yaml
@@ -44,39 +44,10 @@ Metadata:
         default: "Data disk size"
 
 Mappings:
-  Region2AMI:
-    eu-north-1:
-      AMI: ami-0168b2054d2f38cc1
-    ap-south-1:
-      AMI: ami-090609133a86b9723
-    eu-west-3:
-      AMI: ami-07f75642b87ea58ce
-    eu-west-2:
-      AMI: ami-05c94e542948a2807
-    eu-west-1:
-      AMI: ami-043847b30c32c01cf
-    ap-northeast-2:
-      AMI: ami-01e7286e8e09d809f
-    ap-northeast-1:
-      AMI: ami-08455f1340543554c
-    sa-east-1:
-      AMI: ami-0d6806446a46f9b9c
-    ca-central-1:
-      AMI: ami-07fa365b1f79fcbb1
-    ap-southeast-1:
-      AMI: ami-0ff297662c4840aa5
-    ap-southeast-2:
-      AMI: ami-0009ba887e00637bd
-    eu-central-1:
-      AMI: ami-05034a7fcbfe5d5af
-    us-east-1:
-      AMI: ami-022d4249382309a48
-    us-east-2:
-      AMI: ami-03f4121463e28151e
-    us-west-1:
-      AMI: ami-0fa12818adfd95e6e
-    us-west-2:
-      AMI: ami-0f81e6e71078b75b6
+  Variables:
+    LatestAmiId:
+      # Get the latest AMI ID from Canonical's public Systems Manager Parameter
+      amd64: "{{resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id}}"
 
 Resources:
   InstanceSecurityGroup:
@@ -124,7 +95,7 @@ Resources:
     Properties:
       InstanceType: !Ref InstanceType
       AvailabilityZone: !Ref "AWS::NoValue"
-      ImageId: !FindInMap [Region2AMI, !Ref "AWS::Region", AMI]
+      ImageId: !FindInMap [Variables, LatestAmiId, amd64]
       KeyName: !Ref KeyName
       SecurityGroups:
         - !Ref InstanceSecurityGroup

--- a/gcp-deployment-manager/templates/docksal_template.jinja
+++ b/gcp-deployment-manager/templates/docksal_template.jinja
@@ -26,7 +26,7 @@ resources:
         boot: true
         autoDelete: true
         initializeParams:
-          sourceImage: https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2004-focal-v20220331
+          sourceImage: https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2204-jammy-v20230124
       - deviceName: docksal-sandbox-disk-data
         source: docksal-sandbox-disk
       {% if properties["startup"] or properties["docksalDnsDomain"] %}


### PR DESCRIPTION
## AWS

- Updated base images to Ubuntu 22.04 (jammy) (amd64/arm64)

Templates:

- Basic: [v3.4.0](https://docksal-aws-templates.s3.us-east-2.amazonaws.com/sandbox-server/v3.4.0/basic.json)
- Advanced: [v3.4.0](https://docksal-aws-templates.s3.us-east-2.amazonaws.com/sandbox-server/v3.4.0/advanced.json)

## GCP 

- Updated base image to Ubuntu 22.04 (jammy) (`ubuntu-minimal-2204-jammy-v20230124`)
